### PR TITLE
Shape/ductus updates to ktA (U+11083), ktAA (U+11084), ktO (U+1108B) and ktAU (U+1…

### DIFF
--- a/sources/NotoSansKaithi.glyphs
+++ b/sources/NotoSansKaithi.glyphs
@@ -1,13 +1,7 @@
 {
-.appVersion = "3243";
+.appVersion = "3316";
 DisplayStrings = (
-"/ktPa/ktVSU/ktPa/ktPa",
-"/ktVSR/space/space/ktVSU/space/space/ktVSUU/space/space/space",
-"/ktYa/ktVa",
-"/ktVSR",
-"/ktVSU.alt/ktVirama",
-"/ktKMa/ktYa/ktVa/ktSHa/ktPTa/ktKYa/ktSSRa/ktSRa/ktBHYa/ktKSa/ktVRa/ktKMRa/ktKMRa.var/ktKSa.var/ktKYa.varKa/ktNNa.var/ktKTHRa.var/ktLa.var/ktPHRa.var",
-"/uni25CC/ktVSE"
+"\012/ktA/ktAA/ktO/ktAU \012/ktA/ktSHa/ktSU/ktSa/space \012/ktE/ktGa/ktVSO/space/ktSa/ktVSUU/ktMa/space/ktA/ktPa/ktNa/space/ktO/ktKa/ktRa/ktVSAA/space \012/ktE/ktGa/ktVSO/space/ktSa/ktVSUU/ktMa/space/ktA/ktPa/ktNa/space/ktO/ktKa/ktRa/ktVSAA/space \012"
 );
 classes = (
 {
@@ -885,20 +879,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
+name = bottom;
 position = "{297, 0}";
 },
 {
-name = topright;
-position = "{439, 697}";
-},
-{
-name = bottom;
+name = bottom2;
 position = "{297, 0}";
 },
 {
 name = top;
 position = "{297, 627}";
+},
+{
+name = topright;
+position = "{439, 697}";
 }
 );
 layerId = UUID0;
@@ -1337,8 +1331,9 @@ script = kthi;
 category = Letter;
 },
 {
+color = 4;
 glyphname = ktA;
-lastChange = "2023-06-05 09:55:36 +0000";
+lastChange = "2024-09-19 11:10:47 +0000";
 layers = (
 {
 anchors = (
@@ -1347,15 +1342,223 @@ name = bottom2;
 position = "{495, 0}";
 },
 {
+name = top;
+position = "{380, 627}";
+},
+{
 name = topright;
 position = "{493, 697}";
+}
+);
+guideLines = (
+{
+angle = 123.8962;
+position = "{176, 71}";
+},
+{
+angle = 123.8962;
+position = "{171, 71}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"536 622 LINE",
+"455 622 LINE",
+"455 292 LINE",
+"154 103 LINE",
+"197 39 LINE",
+"455 216 LINE",
+"458 216 LINE",
+"457 211 OFFCURVE",
+"455 193 OFFCURVE",
+"455 159 CURVE SMOOTH",
+"455 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 213 OFFCURVE",
+"371 327 OFFCURVE",
+"371 470 CURVE SMOOTH",
+"371 560 OFFCURVE",
+"321 627 OFFCURVE",
+"229 627 CURVE SMOOTH",
+"157 627 OFFCURVE",
+"106 576 OFFCURVE",
+"106 505 CURVE SMOOTH",
+"106 440 OFFCURVE",
+"139 381 OFFCURVE",
+"236 319 CURVE",
+"278 369 LINE",
+"202 406 OFFCURVE",
+"187 455 OFFCURVE",
+"187 494 CURVE SMOOTH",
+"187 534 OFFCURVE",
+"206 556 OFFCURVE",
+"236 556 CURVE SMOOTH",
+"270 556 OFFCURVE",
+"290 526 OFFCURVE",
+"290 477 CURVE SMOOTH",
+"290 357 OFFCURVE",
+"206 291 OFFCURVE",
+"145 274 CURVE",
+"217 285 LINE",
+"173 314 OFFCURVE",
+"139 329 OFFCURVE",
+"105 329 CURVE SMOOTH",
+"61 329 OFFCURVE",
+"40 305 OFFCURVE",
+"40 274 CURVE SMOOTH",
+"40 243 OFFCURVE",
+"71 213 OFFCURVE",
+"125 213 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 201 LINE",
+"308 227 OFFCURVE",
+"275 252 OFFCURVE",
+"237 275 CURVE",
+"183 240 LINE",
+"221 217 OFFCURVE",
+"257 192 OFFCURVE",
+"292 165 CURVE"
+);
+}
+);
+width = 619;
+},
+{
+anchors = (
+{
+name = bottom2;
+position = "{495, 0}";
 },
 {
 name = top;
 position = "{380, 627}";
+},
+{
+name = topright;
+position = "{493, 697}";
 }
 );
-layerId = UUID0;
+associatedMasterId = UUID0;
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"536 -1200 LINE",
+"536 -578 LINE",
+"455 -578 LINE",
+"455 -919 LINE",
+"390 -958 LINE",
+"348 -926 OFFCURVE",
+"312 -898 OFFCURVE",
+"283 -872 CURVE",
+"334 -829 OFFCURVE",
+"368 -779 OFFCURVE",
+"368 -714 CURVE SMOOTH",
+"368 -654 OFFCURVE",
+"326 -573 OFFCURVE",
+"229 -573 CURVE SMOOTH",
+"159 -573 OFFCURVE",
+"106 -621 OFFCURVE",
+"106 -697 CURVE SMOOTH",
+"106 -753 OFFCURVE",
+"134 -804 OFFCURVE",
+"178 -853 CURVE",
+"138 -877 OFFCURVE",
+"89 -899 OFFCURVE",
+"39 -921 CURVE",
+"75 -992 LINE",
+"132 -965 OFFCURVE",
+"188 -938 OFFCURVE",
+"235 -908 CURVE",
+"266 -935 OFFCURVE",
+"300 -962 OFFCURVE",
+"336 -990 CURVE",
+"154 -1097 LINE",
+"197 -1161 LINE",
+"455 -995 LINE",
+"458 -995 LINE",
+"457 -1000 OFFCURVE",
+"455 -1018 OFFCURVE",
+"455 -1052 CURVE SMOOTH",
+"455 -1200 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 -782 OFFCURVE",
+"187 -748 OFFCURVE",
+"187 -712 CURVE SMOOTH",
+"187 -673 OFFCURVE",
+"207 -644 OFFCURVE",
+"239 -644 CURVE SMOOTH",
+"271 -644 OFFCURVE",
+"287 -671 OFFCURVE",
+"287 -704 CURVE SMOOTH",
+"287 -749 OFFCURVE",
+"265 -785 OFFCURVE",
+"229 -816 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"228 282 OFFCURVE",
+"306 274 OFFCURVE",
+"326 172 CURVE",
+"379 202 LINE",
+"350 302 OFFCURVE",
+"273 335 OFFCURVE",
+"166 307 CURVE",
+"226 291 LINE",
+"325 348 OFFCURVE",
+"368 412 OFFCURVE",
+"368 486 CURVE SMOOTH",
+"368 546 OFFCURVE",
+"326 627 OFFCURVE",
+"229 627 CURVE SMOOTH",
+"159 627 OFFCURVE",
+"106 579 OFFCURVE",
+"106 503 CURVE SMOOTH",
+"106 447 OFFCURVE",
+"134 396 OFFCURVE",
+"181 344 CURVE",
+"144 322 OFFCURVE",
+"87 299 OFFCURVE",
+"38 276 CURVE",
+"84 208 LINE",
+"101 219 OFFCURVE",
+"133 237 OFFCURVE",
+"158 249 CURVE SMOOTH"
+);
+}
+);
+};
+guideLines = (
+{
+angle = 123.8962;
+position = "{176, 71}";
+},
+{
+angle = 123.8962;
+position = "{171, 71}";
+}
+);
+layerId = "FD80155B-72EB-40D7-A0AF-A7C46487DFAA";
+name = "Sep 19, 24 at 11:31";
 paths = (
 {
 closed = 1;
@@ -1426,8 +1629,9 @@ script = kthi;
 category = Letter;
 },
 {
+color = 4;
 glyphname = ktAA;
-lastChange = "2023-06-05 09:55:36 +0000";
+lastChange = "2024-09-19 10:15:37 +0000";
 layers = (
 {
 anchors = (
@@ -1436,15 +1640,272 @@ name = bottom2;
 position = "{496, 0}";
 },
 {
+name = top;
+position = "{496, 627}";
+},
+{
 name = topright;
 position = "{739, 697}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"782 0 LINE",
+"782 622 LINE",
+"702 622 LINE",
+"702 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"536 622 LINE",
+"455 622 LINE",
+"455 292 LINE",
+"154 103 LINE",
+"197 39 LINE",
+"455 216 LINE",
+"458 216 LINE",
+"457 211 OFFCURVE",
+"455 193 OFFCURVE",
+"455 159 CURVE SMOOTH",
+"455 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 213 OFFCURVE",
+"371 327 OFFCURVE",
+"371 472 CURVE SMOOTH",
+"371 560 OFFCURVE",
+"321 627 OFFCURVE",
+"230 627 CURVE SMOOTH",
+"157 627 OFFCURVE",
+"106 576 OFFCURVE",
+"106 505 CURVE SMOOTH",
+"106 440 OFFCURVE",
+"132 381 OFFCURVE",
+"236 319 CURVE",
+"278 369 LINE",
+"202 406 OFFCURVE",
+"187 455 OFFCURVE",
+"187 494 CURVE SMOOTH",
+"187 534 OFFCURVE",
+"206 556 OFFCURVE",
+"238 556 CURVE SMOOTH",
+"270 556 OFFCURVE",
+"290 526 OFFCURVE",
+"290 478 CURVE SMOOTH",
+"290 387 OFFCURVE",
+"224 308 OFFCURVE",
+"173 287 CURVE",
+"220 284 LINE",
+"192 312 OFFCURVE",
+"151 329 OFFCURVE",
+"116 329 CURVE SMOOTH",
+"75 329 OFFCURVE",
+"52 305 OFFCURVE",
+"52 274 CURVE SMOOTH",
+"52 237 OFFCURVE",
+"82 213 OFFCURVE",
+"132 213 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"194 239 LINE",
+"219 227 OFFCURVE",
+"270 184 OFFCURVE",
+"281 160 CURVE",
+"330 196 LINE",
+"320 214 OFFCURVE",
+"277 252 OFFCURVE",
+"250 270 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"782 0 LINE",
+"782 622 LINE",
+"702 622 LINE",
+"702 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"536 622 LINE",
+"455 622 LINE",
+"455 292 LINE",
+"154 103 LINE",
+"197 39 LINE",
+"455 216 LINE",
+"458 216 LINE",
+"457 211 OFFCURVE",
+"455 193 OFFCURVE",
+"455 159 CURVE SMOOTH",
+"455 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 213 OFFCURVE",
+"371 327 OFFCURVE",
+"371 470 CURVE SMOOTH",
+"371 560 OFFCURVE",
+"321 627 OFFCURVE",
+"229 627 CURVE SMOOTH",
+"157 627 OFFCURVE",
+"106 576 OFFCURVE",
+"106 505 CURVE SMOOTH",
+"106 440 OFFCURVE",
+"139 381 OFFCURVE",
+"236 319 CURVE",
+"278 369 LINE",
+"202 406 OFFCURVE",
+"187 455 OFFCURVE",
+"187 494 CURVE SMOOTH",
+"187 534 OFFCURVE",
+"206 556 OFFCURVE",
+"236 556 CURVE SMOOTH",
+"270 556 OFFCURVE",
+"290 526 OFFCURVE",
+"290 477 CURVE SMOOTH",
+"290 357 OFFCURVE",
+"206 291 OFFCURVE",
+"145 274 CURVE",
+"217 285 LINE",
+"173 314 OFFCURVE",
+"139 329 OFFCURVE",
+"105 329 CURVE SMOOTH",
+"61 329 OFFCURVE",
+"40 305 OFFCURVE",
+"40 274 CURVE SMOOTH",
+"40 243 OFFCURVE",
+"71 213 OFFCURVE",
+"125 213 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 201 LINE",
+"308 227 OFFCURVE",
+"275 252 OFFCURVE",
+"237 275 CURVE",
+"183 240 LINE",
+"221 217 OFFCURVE",
+"257 192 OFFCURVE",
+"292 165 CURVE"
+);
+}
+);
+width = 860;
+},
+{
+anchors = (
+{
+name = bottom2;
+position = "{496, 0}";
 },
 {
 name = top;
 position = "{496, 627}";
+},
+{
+name = topright;
+position = "{739, 697}";
 }
 );
-layerId = UUID0;
+associatedMasterId = UUID0;
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"536 622 LINE",
+"455 622 LINE",
+"455 281 LINE",
+"390 242 LINE",
+"348 274 OFFCURVE",
+"312 302 OFFCURVE",
+"283 328 CURVE",
+"334 371 OFFCURVE",
+"368 421 OFFCURVE",
+"368 486 CURVE SMOOTH",
+"368 546 OFFCURVE",
+"326 627 OFFCURVE",
+"229 627 CURVE SMOOTH",
+"159 627 OFFCURVE",
+"106 579 OFFCURVE",
+"106 503 CURVE SMOOTH",
+"106 447 OFFCURVE",
+"134 396 OFFCURVE",
+"178 347 CURVE",
+"138 323 OFFCURVE",
+"89 301 OFFCURVE",
+"39 279 CURVE",
+"75 208 LINE",
+"132 235 OFFCURVE",
+"188 262 OFFCURVE",
+"235 292 CURVE",
+"266 265 OFFCURVE",
+"300 238 OFFCURVE",
+"336 210 CURVE",
+"154 103 LINE",
+"197 39 LINE",
+"455 205 LINE",
+"458 205 LINE",
+"457 200 OFFCURVE",
+"455 182 OFFCURVE",
+"455 148 CURVE SMOOTH",
+"455 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 418 OFFCURVE",
+"187 452 OFFCURVE",
+"187 488 CURVE SMOOTH",
+"187 527 OFFCURVE",
+"207 556 OFFCURVE",
+"239 556 CURVE SMOOTH",
+"271 556 OFFCURVE",
+"287 529 OFFCURVE",
+"287 496 CURVE SMOOTH",
+"287 451 OFFCURVE",
+"265 415 OFFCURVE",
+"229 384 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"782 0 LINE",
+"782 622 LINE",
+"702 622 LINE",
+"702 0 LINE"
+);
+}
+);
+};
+layerId = "318C1DC4-EE15-4F43-B650-DF34F04710C3";
+name = "Sep 19, 24 at 12:05";
 paths = (
 {
 closed = 1;
@@ -1534,12 +1995,12 @@ name = bottom2;
 position = "{220, 0}";
 },
 {
-name = topright;
-position = "{306, 702}";
-},
-{
 name = top;
 position = "{300, 627}";
+},
+{
+name = topright;
+position = "{306, 702}";
 }
 );
 layerId = UUID0;
@@ -1629,12 +2090,12 @@ name = bottom2;
 position = "{259, 0}";
 },
 {
-name = topright;
-position = "{415, 906}";
-},
-{
 name = top;
 position = "{439, 816}";
+},
+{
+name = topright;
+position = "{415, 906}";
 }
 );
 layerId = UUID0;
@@ -1743,12 +2204,12 @@ name = bottom2;
 position = "{280, 0}";
 },
 {
-name = topright;
-position = "{268, 697}";
-},
-{
 name = top;
 position = "{251, 627}";
+},
+{
+name = topright;
+position = "{268, 697}";
 }
 );
 layerId = UUID0;
@@ -1825,12 +2286,12 @@ name = bottom2;
 position = "{280, 0}";
 },
 {
-name = topright;
-position = "{268, 697}";
-},
-{
 name = top;
 position = "{363, 627}";
+},
+{
+name = topright;
+position = "{268, 697}";
 }
 );
 layerId = UUID0;
@@ -1920,12 +2381,12 @@ name = bottom2;
 position = "{206, 0}";
 },
 {
-name = topright;
-position = "{443, 697}";
-},
-{
 name = top;
 position = "{290, 627}";
+},
+{
+name = topright;
+position = "{443, 697}";
 }
 );
 layerId = UUID0;
@@ -1979,12 +2440,12 @@ name = bottom2;
 position = "{206, 0}";
 },
 {
-name = topright;
-position = "{441, 802}";
-},
-{
 name = top;
 position = "{460, 719}";
+},
+{
+name = topright;
+position = "{441, 802}";
 }
 );
 layerId = UUID0;
@@ -2037,8 +2498,9 @@ script = kthi;
 category = Letter;
 },
 {
+color = 4;
 glyphname = ktO;
-lastChange = "2023-06-05 09:55:36 +0000";
+lastChange = "2024-09-19 10:15:40 +0000";
 layers = (
 {
 anchors = (
@@ -2047,15 +2509,289 @@ name = bottom2;
 position = "{495, 0}";
 },
 {
+name = top;
+position = "{732, 719}";
+},
+{
 name = topright;
 position = "{713, 802}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"536 622 LINE",
+"455 622 LINE",
+"455 281 LINE",
+"390 242 LINE",
+"348 274 OFFCURVE",
+"312 302 OFFCURVE",
+"283 328 CURVE",
+"334 371 OFFCURVE",
+"368 421 OFFCURVE",
+"368 486 CURVE SMOOTH",
+"368 546 OFFCURVE",
+"326 627 OFFCURVE",
+"229 627 CURVE SMOOTH",
+"159 627 OFFCURVE",
+"106 579 OFFCURVE",
+"106 503 CURVE SMOOTH",
+"106 447 OFFCURVE",
+"134 396 OFFCURVE",
+"178 347 CURVE",
+"138 323 OFFCURVE",
+"89 301 OFFCURVE",
+"39 279 CURVE",
+"75 208 LINE",
+"132 235 OFFCURVE",
+"188 262 OFFCURVE",
+"235 292 CURVE",
+"266 265 OFFCURVE",
+"300 238 OFFCURVE",
+"336 210 CURVE",
+"154 103 LINE",
+"197 39 LINE",
+"455 205 LINE",
+"458 205 LINE",
+"457 200 OFFCURVE",
+"455 182 OFFCURVE",
+"455 148 CURVE SMOOTH",
+"455 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 418 OFFCURVE",
+"187 452 OFFCURVE",
+"187 488 CURVE SMOOTH",
+"187 527 OFFCURVE",
+"207 556 OFFCURVE",
+"239 556 CURVE SMOOTH",
+"271 556 OFFCURVE",
+"287 529 OFFCURVE",
+"287 496 CURVE SMOOTH",
+"287 451 OFFCURVE",
+"265 415 OFFCURVE",
+"229 384 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"782 0 LINE",
+"782 622 LINE",
+"702 622 LINE",
+"702 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"757 727 LINE",
+"338 906 LINE",
+"303 834 LINE",
+"731 674 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"782 0 LINE",
+"782 622 LINE",
+"702 622 LINE",
+"702 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"757 727 LINE",
+"338 906 LINE",
+"303 834 LINE",
+"731 674 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"536 622 LINE",
+"455 622 LINE",
+"455 292 LINE",
+"154 103 LINE",
+"197 39 LINE",
+"455 216 LINE",
+"458 216 LINE",
+"457 211 OFFCURVE",
+"455 193 OFFCURVE",
+"455 159 CURVE SMOOTH",
+"455 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 213 OFFCURVE",
+"371 327 OFFCURVE",
+"371 470 CURVE SMOOTH",
+"371 560 OFFCURVE",
+"321 627 OFFCURVE",
+"229 627 CURVE SMOOTH",
+"157 627 OFFCURVE",
+"106 576 OFFCURVE",
+"106 505 CURVE SMOOTH",
+"106 440 OFFCURVE",
+"139 381 OFFCURVE",
+"236 319 CURVE",
+"278 369 LINE",
+"202 406 OFFCURVE",
+"187 455 OFFCURVE",
+"187 494 CURVE SMOOTH",
+"187 534 OFFCURVE",
+"206 556 OFFCURVE",
+"236 556 CURVE SMOOTH",
+"270 556 OFFCURVE",
+"290 526 OFFCURVE",
+"290 477 CURVE SMOOTH",
+"290 357 OFFCURVE",
+"206 291 OFFCURVE",
+"145 274 CURVE",
+"217 285 LINE",
+"173 314 OFFCURVE",
+"139 329 OFFCURVE",
+"105 329 CURVE SMOOTH",
+"61 329 OFFCURVE",
+"40 305 OFFCURVE",
+"40 274 CURVE SMOOTH",
+"40 243 OFFCURVE",
+"71 213 OFFCURVE",
+"125 213 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 201 LINE",
+"308 227 OFFCURVE",
+"275 252 OFFCURVE",
+"237 275 CURVE",
+"183 240 LINE",
+"221 217 OFFCURVE",
+"257 192 OFFCURVE",
+"292 165 CURVE"
+);
+}
+);
+width = 865;
+},
+{
+anchors = (
+{
+name = bottom2;
+position = "{495, 0}";
 },
 {
 name = top;
 position = "{732, 719}";
+},
+{
+name = topright;
+position = "{713, 802}";
 }
 );
-layerId = UUID0;
+associatedMasterId = UUID0;
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"536 622 LINE",
+"455 622 LINE",
+"455 281 LINE",
+"390 242 LINE",
+"348 274 OFFCURVE",
+"312 302 OFFCURVE",
+"283 328 CURVE",
+"334 371 OFFCURVE",
+"368 421 OFFCURVE",
+"368 486 CURVE SMOOTH",
+"368 546 OFFCURVE",
+"326 627 OFFCURVE",
+"229 627 CURVE SMOOTH",
+"159 627 OFFCURVE",
+"106 579 OFFCURVE",
+"106 503 CURVE SMOOTH",
+"106 447 OFFCURVE",
+"134 396 OFFCURVE",
+"178 347 CURVE",
+"138 323 OFFCURVE",
+"89 301 OFFCURVE",
+"39 279 CURVE",
+"75 208 LINE",
+"132 235 OFFCURVE",
+"188 262 OFFCURVE",
+"235 292 CURVE",
+"266 265 OFFCURVE",
+"300 238 OFFCURVE",
+"336 210 CURVE",
+"154 103 LINE",
+"197 39 LINE",
+"455 205 LINE",
+"458 205 LINE",
+"457 200 OFFCURVE",
+"455 182 OFFCURVE",
+"455 148 CURVE SMOOTH",
+"455 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 418 OFFCURVE",
+"187 452 OFFCURVE",
+"187 488 CURVE SMOOTH",
+"187 527 OFFCURVE",
+"207 556 OFFCURVE",
+"239 556 CURVE SMOOTH",
+"271 556 OFFCURVE",
+"287 529 OFFCURVE",
+"287 496 CURVE SMOOTH",
+"287 451 OFFCURVE",
+"265 415 OFFCURVE",
+"229 384 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"782 0 LINE",
+"782 622 LINE",
+"702 622 LINE",
+"702 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"757 727 LINE",
+"338 906 LINE",
+"303 834 LINE",
+"731 674 LINE"
+);
+}
+);
+};
+layerId = "00647F56-4118-4E15-BE8D-F6DC0042ECA5";
+name = "Sep 19, 24 at 12:05";
 paths = (
 {
 closed = 1;
@@ -2144,8 +2880,9 @@ script = kthi;
 category = Letter;
 },
 {
+color = 4;
 glyphname = ktAU;
-lastChange = "2023-06-05 09:55:36 +0000";
+lastChange = "2024-09-19 10:15:42 +0000";
 layers = (
 {
 anchors = (
@@ -2154,15 +2891,322 @@ name = bottom2;
 position = "{496, 0}";
 },
 {
+name = top;
+position = "{800, 834}";
+},
+{
 name = topright;
 position = "{751, 849}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"536 622 LINE",
+"455 622 LINE",
+"455 281 LINE",
+"390 242 LINE",
+"348 274 OFFCURVE",
+"312 302 OFFCURVE",
+"283 328 CURVE",
+"334 371 OFFCURVE",
+"368 421 OFFCURVE",
+"368 486 CURVE SMOOTH",
+"368 546 OFFCURVE",
+"326 627 OFFCURVE",
+"229 627 CURVE SMOOTH",
+"159 627 OFFCURVE",
+"106 579 OFFCURVE",
+"106 503 CURVE SMOOTH",
+"106 447 OFFCURVE",
+"134 396 OFFCURVE",
+"178 347 CURVE",
+"138 323 OFFCURVE",
+"89 301 OFFCURVE",
+"39 279 CURVE",
+"75 208 LINE",
+"132 235 OFFCURVE",
+"188 262 OFFCURVE",
+"235 292 CURVE",
+"266 265 OFFCURVE",
+"300 238 OFFCURVE",
+"336 210 CURVE",
+"154 103 LINE",
+"197 39 LINE",
+"455 205 LINE",
+"458 205 LINE",
+"457 200 OFFCURVE",
+"455 182 OFFCURVE",
+"455 148 CURVE SMOOTH",
+"455 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 418 OFFCURVE",
+"187 452 OFFCURVE",
+"187 488 CURVE SMOOTH",
+"187 527 OFFCURVE",
+"207 556 OFFCURVE",
+"239 556 CURVE SMOOTH",
+"271 556 OFFCURVE",
+"287 529 OFFCURVE",
+"287 496 CURVE SMOOTH",
+"287 451 OFFCURVE",
+"265 415 OFFCURVE",
+"229 384 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"782 0 LINE",
+"782 622 LINE",
+"702 622 LINE",
+"702 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"760 727 LINE",
+"740 797 OFFCURVE",
+"702 873 OFFCURVE",
+"550 1024 CURVE",
+"496 971 LINE",
+"608 860 OFFCURVE",
+"666 812 OFFCURVE",
+"699 750 CURVE",
+"695 746 LINE",
+"681 756 OFFCURVE",
+"648 775 OFFCURVE",
+"611 791 CURVE SMOOTH",
+"341 906 LINE",
+"306 834 LINE",
+"734 674 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"782 0 LINE",
+"782 622 LINE",
+"702 622 LINE",
+"702 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"760 727 LINE",
+"740 797 OFFCURVE",
+"702 873 OFFCURVE",
+"550 1024 CURVE",
+"496 971 LINE",
+"608 860 OFFCURVE",
+"666 812 OFFCURVE",
+"699 750 CURVE",
+"695 746 LINE",
+"681 756 OFFCURVE",
+"648 775 OFFCURVE",
+"611 791 CURVE SMOOTH",
+"341 906 LINE",
+"306 834 LINE",
+"734 674 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"536 622 LINE",
+"455 622 LINE",
+"455 292 LINE",
+"154 103 LINE",
+"197 39 LINE",
+"455 216 LINE",
+"458 216 LINE",
+"457 211 OFFCURVE",
+"455 193 OFFCURVE",
+"455 159 CURVE SMOOTH",
+"455 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 213 OFFCURVE",
+"371 327 OFFCURVE",
+"371 470 CURVE SMOOTH",
+"371 560 OFFCURVE",
+"321 627 OFFCURVE",
+"229 627 CURVE SMOOTH",
+"157 627 OFFCURVE",
+"106 576 OFFCURVE",
+"106 505 CURVE SMOOTH",
+"106 440 OFFCURVE",
+"139 381 OFFCURVE",
+"236 319 CURVE",
+"278 369 LINE",
+"202 406 OFFCURVE",
+"187 455 OFFCURVE",
+"187 494 CURVE SMOOTH",
+"187 534 OFFCURVE",
+"206 556 OFFCURVE",
+"236 556 CURVE SMOOTH",
+"270 556 OFFCURVE",
+"290 526 OFFCURVE",
+"290 477 CURVE SMOOTH",
+"290 357 OFFCURVE",
+"206 291 OFFCURVE",
+"145 274 CURVE",
+"217 285 LINE",
+"173 314 OFFCURVE",
+"139 329 OFFCURVE",
+"105 329 CURVE SMOOTH",
+"61 329 OFFCURVE",
+"40 305 OFFCURVE",
+"40 274 CURVE SMOOTH",
+"40 243 OFFCURVE",
+"71 213 OFFCURVE",
+"125 213 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 201 LINE",
+"308 227 OFFCURVE",
+"275 252 OFFCURVE",
+"237 275 CURVE",
+"183 240 LINE",
+"221 217 OFFCURVE",
+"257 192 OFFCURVE",
+"292 165 CURVE"
+);
+}
+);
+width = 865;
+},
+{
+anchors = (
+{
+name = bottom2;
+position = "{496, 0}";
 },
 {
 name = top;
 position = "{800, 834}";
+},
+{
+name = topright;
+position = "{751, 849}";
 }
 );
-layerId = UUID0;
+associatedMasterId = UUID0;
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"536 622 LINE",
+"455 622 LINE",
+"455 281 LINE",
+"390 242 LINE",
+"348 274 OFFCURVE",
+"312 302 OFFCURVE",
+"283 328 CURVE",
+"334 371 OFFCURVE",
+"368 421 OFFCURVE",
+"368 486 CURVE SMOOTH",
+"368 546 OFFCURVE",
+"326 627 OFFCURVE",
+"229 627 CURVE SMOOTH",
+"159 627 OFFCURVE",
+"106 579 OFFCURVE",
+"106 503 CURVE SMOOTH",
+"106 447 OFFCURVE",
+"134 396 OFFCURVE",
+"178 347 CURVE",
+"138 323 OFFCURVE",
+"89 301 OFFCURVE",
+"39 279 CURVE",
+"75 208 LINE",
+"132 235 OFFCURVE",
+"188 262 OFFCURVE",
+"235 292 CURVE",
+"266 265 OFFCURVE",
+"300 238 OFFCURVE",
+"336 210 CURVE",
+"154 103 LINE",
+"197 39 LINE",
+"455 205 LINE",
+"458 205 LINE",
+"457 200 OFFCURVE",
+"455 182 OFFCURVE",
+"455 148 CURVE SMOOTH",
+"455 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 418 OFFCURVE",
+"187 452 OFFCURVE",
+"187 488 CURVE SMOOTH",
+"187 527 OFFCURVE",
+"207 556 OFFCURVE",
+"239 556 CURVE SMOOTH",
+"271 556 OFFCURVE",
+"287 529 OFFCURVE",
+"287 496 CURVE SMOOTH",
+"287 451 OFFCURVE",
+"265 415 OFFCURVE",
+"229 384 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"782 0 LINE",
+"782 622 LINE",
+"702 622 LINE",
+"702 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"760 727 LINE",
+"740 797 OFFCURVE",
+"702 873 OFFCURVE",
+"550 1024 CURVE",
+"496 971 LINE",
+"608 860 OFFCURVE",
+"666 812 OFFCURVE",
+"699 750 CURVE",
+"695 746 LINE",
+"681 756 OFFCURVE",
+"648 775 OFFCURVE",
+"611 791 CURVE SMOOTH",
+"341 906 LINE",
+"306 834 LINE",
+"734 674 LINE"
+);
+}
+);
+};
+layerId = "A2BF0021-9C8D-4D80-9F4E-B681D563F420";
+name = "Sep 19, 24 at 12:05";
 paths = (
 {
 closed = 1;
@@ -2268,20 +3312,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{396, 0}";
-},
-{
-name = topright;
-position = "{393, 697}";
-},
-{
 name = bottom;
 position = "{395, 0}";
 },
 {
+name = bottom2;
+position = "{396, 0}";
+},
+{
 name = top;
 position = "{396, 627}";
+},
+{
+name = topright;
+position = "{393, 697}";
 }
 );
 layerId = UUID0;
@@ -2369,20 +3413,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{352, 200}";
-},
-{
-name = topright;
-position = "{605, 697}";
-},
-{
 name = bottom;
 position = "{605, 0}";
 },
 {
+name = bottom2;
+position = "{352, 200}";
+},
+{
 name = top;
 position = "{354, 627}";
+},
+{
+name = topright;
+position = "{605, 697}";
 }
 );
 layerId = UUID0;
@@ -2450,20 +3494,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{287, 100}";
-},
-{
-name = topright;
-position = "{482, 697}";
-},
-{
 name = bottom;
 position = "{478, 0}";
 },
 {
+name = bottom2;
+position = "{287, 100}";
+},
+{
 name = top;
 position = "{322, 627}";
+},
+{
+name = topright;
+position = "{482, 697}";
 }
 );
 layerId = UUID0;
@@ -2517,20 +3561,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{283, 80}";
-},
-{
-name = topright;
-position = "{478, 697}";
-},
-{
 name = bottom;
 position = "{478, 0}";
 },
 {
+name = bottom2;
+position = "{283, 80}";
+},
+{
 name = top;
 position = "{304, 627}";
+},
+{
+name = topright;
+position = "{478, 697}";
 }
 );
 layerId = UUID0;
@@ -2599,20 +3643,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{348, 0}";
-},
-{
-name = topright;
-position = "{429, 697}";
-},
-{
 name = bottom;
 position = "{341, 0}";
 },
 {
+name = bottom2;
+position = "{348, 0}";
+},
+{
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{429, 697}";
 }
 );
 layerId = UUID0;
@@ -2665,20 +3709,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{268, 80}";
-},
-{
-name = topright;
-position = "{435, 697}";
-},
-{
 name = bottom;
 position = "{439, 0}";
 },
 {
+name = bottom2;
+position = "{268, 80}";
+},
+{
 name = top;
 position = "{313, 627}";
+},
+{
+name = topright;
+position = "{435, 697}";
 }
 );
 layerId = UUID0;
@@ -2737,20 +3781,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{374, 0}";
-},
-{
-name = topright;
-position = "{519, 697}";
-},
-{
 name = bottom;
 position = "{300, 0}";
 },
 {
+name = bottom2;
+position = "{374, 0}";
+},
+{
 name = top;
 position = "{379, 627}";
+},
+{
+name = topright;
+position = "{519, 697}";
 }
 );
 layerId = UUID0;
@@ -2846,20 +3890,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{337, 40}";
-},
-{
-name = topright;
-position = "{449, 697}";
-},
-{
 name = bottom;
 position = "{566, 0}";
 },
 {
+name = bottom2;
+position = "{337, 40}";
+},
+{
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{449, 697}";
 }
 );
 layerId = UUID0;
@@ -2916,20 +3960,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{344, -186}";
-},
-{
-name = topright;
-position = "{410, 701}";
-},
-{
 name = bottom;
 position = "{351, -195}";
 },
 {
+name = bottom2;
+position = "{344, -186}";
+},
+{
 name = top;
 position = "{363, 627}";
+},
+{
+name = topright;
+position = "{410, 701}";
 }
 );
 layerId = UUID0;
@@ -3010,20 +4054,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{283, 130}";
-},
-{
-name = topright;
-position = "{518, 697}";
-},
-{
 name = bottom;
 position = "{517, 0}";
 },
 {
+name = bottom2;
+position = "{283, 130}";
+},
+{
 name = top;
 position = "{307, 627}";
+},
+{
+name = topright;
+position = "{518, 697}";
 }
 );
 layerId = UUID0;
@@ -3095,20 +4139,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{293, 0}";
-},
-{
-name = topright;
-position = "{317, 697}";
-},
-{
 name = bottom;
 position = "{278, 0}";
 },
 {
+name = bottom2;
+position = "{293, 0}";
+},
+{
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{317, 697}";
 }
 );
 layerId = UUID0;
@@ -3155,20 +4199,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{277, 0}";
-},
-{
-name = topright;
-position = "{315, 701}";
-},
-{
 name = bottom;
 position = "{273, 0}";
 },
 {
+name = bottom2;
+position = "{277, 0}";
+},
+{
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{315, 701}";
 }
 );
 layerId = UUID0;
@@ -3231,20 +4275,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{324, 0}";
-},
-{
-name = topright;
-position = "{347, 701}";
-},
-{
 name = bottom;
 position = "{341, 0}";
 },
 {
+name = bottom2;
+position = "{324, 0}";
+},
+{
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{347, 701}";
 }
 );
 layerId = UUID0;
@@ -3307,16 +4351,16 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{347, 701}";
-},
-{
 name = bottom;
 position = "{311, -260}";
 },
 {
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{347, 701}";
 }
 );
 components = (
@@ -3343,20 +4387,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{299, 0}";
-},
-{
-name = topright;
-position = "{318, 697}";
-},
-{
 name = bottom;
 position = "{278, 0}";
 },
 {
+name = bottom2;
+position = "{299, 0}";
+},
+{
 name = top;
 position = "{321, 627}";
+},
+{
+name = topright;
+position = "{318, 697}";
 }
 );
 layerId = UUID0;
@@ -3428,16 +4472,16 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{318, 697}";
-},
-{
 name = bottom;
 position = "{268, -258}";
 },
 {
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{318, 697}";
 }
 );
 components = (
@@ -3464,24 +4508,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{375, 0}";
-},
-{
-name = topright;
-position = "{619, 697}";
+name = Anchor8;
+position = "{581, 0}";
 },
 {
 name = bottom;
 position = "{605, 0}";
 },
 {
+name = bottom2;
+position = "{375, 0}";
+},
+{
 name = top;
 position = "{375, 627}";
 },
 {
-name = Anchor8;
-position = "{581, 0}";
+name = topright;
+position = "{619, 697}";
 }
 );
 layerId = UUID0;
@@ -3526,20 +4570,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{273, 100}";
-},
-{
-name = topright;
-position = "{439, 697}";
-},
-{
 name = bottom;
 position = "{434, 0}";
 },
 {
+name = bottom2;
+position = "{273, 100}";
+},
+{
 name = top;
 position = "{287, 627}";
+},
+{
+name = topright;
+position = "{439, 697}";
 }
 );
 layerId = UUID0;
@@ -3585,20 +4629,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{288, 131}";
-},
-{
-name = topright;
-position = "{459, 697}";
-},
-{
 name = bottom;
 position = "{463, 0}";
 },
 {
+name = bottom2;
+position = "{288, 131}";
+},
+{
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{459, 697}";
 }
 );
 layerId = UUID0;
@@ -3676,20 +4720,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{254, 0}";
-},
-{
-name = topright;
-position = "{287, 701}";
-},
-{
 name = bottom;
 position = "{258, 0}";
 },
 {
+name = bottom2;
+position = "{254, 0}";
+},
+{
 name = top;
 position = "{287, 627}";
+},
+{
+name = topright;
+position = "{287, 701}";
 }
 );
 layerId = UUID0;
@@ -3750,20 +4794,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{296, 100}";
-},
-{
-name = topright;
-position = "{473, 697}";
-},
-{
 name = bottom;
 position = "{468, 0}";
 },
 {
+name = bottom2;
+position = "{296, 100}";
+},
+{
 name = top;
 position = "{297, 627}";
+},
+{
+name = topright;
+position = "{473, 697}";
 }
 );
 layerId = UUID0;
@@ -3818,20 +4862,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{283, 120}";
-},
-{
-name = topright;
-position = "{476, 697}";
-},
-{
 name = bottom;
 position = "{473, 0}";
 },
 {
+name = bottom2;
+position = "{283, 120}";
+},
+{
 name = top;
 position = "{287, 627}";
+},
+{
+name = topright;
+position = "{476, 697}";
 }
 );
 layerId = UUID0;
@@ -3896,20 +4940,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{240, 178}";
-},
-{
-name = topright;
-position = "{419, 697}";
-},
-{
 name = bottom;
 position = "{419, 0}";
 },
 {
+name = bottom2;
+position = "{240, 178}";
+},
+{
 name = top;
 position = "{279, 622}";
+},
+{
+name = topright;
+position = "{419, 697}";
 }
 );
 layerId = UUID0;
@@ -3958,20 +5002,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{333, 0}";
-},
-{
-name = topright;
-position = "{524, 697}";
-},
-{
 name = bottom;
 position = "{454, -10}";
 },
 {
+name = bottom2;
+position = "{333, 0}";
+},
+{
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{524, 697}";
 }
 );
 layerId = UUID0;
@@ -4077,20 +5121,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{254, 158}";
-},
-{
-name = topright;
-position = "{444, 697}";
-},
-{
 name = bottom;
 position = "{444, 0}";
 },
 {
+name = bottom2;
+position = "{254, 158}";
+},
+{
 name = top;
 position = "{285, 627}";
+},
+{
+name = topright;
+position = "{444, 697}";
 }
 );
 layerId = UUID0;
@@ -4149,20 +5193,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{320, 104}";
-},
-{
-name = topright;
-position = "{514, 697}";
-},
-{
 name = bottom;
 position = "{507, 0}";
 },
 {
+name = bottom2;
+position = "{320, 104}";
+},
+{
 name = top;
 position = "{320, 627}";
+},
+{
+name = topright;
+position = "{514, 697}";
 }
 );
 layerId = UUID0;
@@ -4243,20 +5287,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{293, 100}";
-},
-{
-name = topright;
-position = "{473, 697}";
-},
-{
 name = bottom;
 position = "{478, 0}";
 },
 {
+name = bottom2;
+position = "{293, 100}";
+},
+{
 name = top;
 position = "{306, 627}";
+},
+{
+name = topright;
+position = "{473, 697}";
 }
 );
 layerId = UUID0;
@@ -4331,8 +5375,8 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{428, 697}";
+name = Anchor8;
+position = "{391, 0}";
 },
 {
 name = bottom;
@@ -4343,8 +5387,8 @@ name = top;
 position = "{313, 627}";
 },
 {
-name = Anchor8;
-position = "{391, 0}";
+name = topright;
+position = "{428, 697}";
 }
 );
 layerId = UUID0;
@@ -4420,20 +5464,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{330, 0}";
-},
-{
-name = topright;
-position = "{327, 697}";
-},
-{
 name = bottom;
 position = "{322, 0}";
 },
 {
+name = bottom2;
+position = "{330, 0}";
+},
+{
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{327, 697}";
 }
 );
 layerId = UUID0;
@@ -4469,16 +5513,16 @@ layers = (
 {
 anchors = (
 {
+name = bottom;
+position = "{297, 0}";
+},
+{
 name = bottom2;
 position = "{293, 0}";
 },
 {
 name = topright;
 position = "{306, 697}";
-},
-{
-name = bottom;
-position = "{297, 0}";
 }
 );
 layerId = UUID0;
@@ -4555,8 +5599,8 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{451, 697}";
+name = Anchor8;
+position = "{409, 0}";
 },
 {
 name = bottom;
@@ -4567,8 +5611,8 @@ name = top;
 position = "{286, 622}";
 },
 {
-name = Anchor8;
-position = "{409, 0}";
+name = topright;
+position = "{451, 697}";
 }
 );
 layerId = UUID0;
@@ -4635,29 +5679,29 @@ category = Letter;
 },
 {
 glyphname = ktSHa;
-lastChange = "2023-06-05 09:55:36 +0000";
+lastChange = "2024-09-19 10:15:23 +0000";
 layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{293, 0}";
-},
-{
-name = topright;
-position = "{534, 697}";
+name = Anchor8;
+position = "{496, 0}";
 },
 {
 name = bottom;
 position = "{532, 0}";
 },
 {
+name = bottom2;
+position = "{293, 0}";
+},
+{
 name = top;
 position = "{367, 627}";
 },
 {
-name = Anchor8;
-position = "{496, 0}";
+name = topright;
+position = "{534, 697}";
 }
 );
 layerId = UUID0;
@@ -4745,20 +5789,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{225, 200}";
-},
-{
-name = topright;
-position = "{395, 697}";
-},
-{
 name = bottom;
 position = "{395, 0}";
 },
 {
+name = bottom2;
+position = "{225, 200}";
+},
+{
 name = top;
 position = "{260, 627}";
+},
+{
+name = topright;
+position = "{395, 697}";
 }
 );
 layerId = UUID0;
@@ -4817,20 +5861,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{167, 198}";
-},
-{
-name = topright;
-position = "{577, 697}";
-},
-{
 name = bottom;
 position = "{576, 0}";
 },
 {
+name = bottom2;
+position = "{167, 198}";
+},
+{
 name = top;
 position = "{365, 627}";
+},
+{
+name = topright;
+position = "{577, 697}";
 }
 );
 layerId = UUID0;
@@ -4911,20 +5955,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{179, 0}";
-},
-{
-name = topright;
-position = "{295, 701}";
-},
-{
 name = bottom;
 position = "{324, -85}";
 },
 {
+name = bottom2;
+position = "{179, 0}";
+},
+{
 name = top;
 position = "{281, 627}";
+},
+{
+name = topright;
+position = "{295, 701}";
 }
 );
 layerId = UUID0;
@@ -5001,12 +6045,12 @@ name = bottom2;
 position = "{124, 0}";
 },
 {
-name = topright;
-position = "{121, 697}";
-},
-{
 name = top;
 position = "{124, 627}";
+},
+{
+name = topright;
+position = "{121, 697}";
 }
 );
 layerId = UUID0;
@@ -5035,12 +6079,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{703, 810}";
-},
-{
 name = top;
 position = "{703, 729}";
+},
+{
+name = topright;
+position = "{703, 810}";
 }
 );
 layerId = UUID0;
@@ -5085,12 +6129,12 @@ name = bottom2;
 position = "{126, 0}";
 },
 {
-name = topright;
-position = "{42, 906}";
-},
-{
 name = top;
 position = "{262, 627}";
+},
+{
+name = topright;
+position = "{42, 906}";
 }
 );
 layerId = UUID0;
@@ -5335,12 +6379,12 @@ name = Anchor12;
 position = "{-89, 848}";
 },
 {
-name = top;
-position = "{-24, 850}";
-},
-{
 name = _topright;
 position = "{-147, 683}";
+},
+{
+name = top;
+position = "{-24, 850}";
 }
 );
 layerId = UUID0;
@@ -5385,12 +6429,12 @@ name = bottom2;
 position = "{119, 0}";
 },
 {
-name = topright;
-position = "{102, 802}";
-},
-{
 name = top;
 position = "{170, 671}";
+},
+{
+name = topright;
+position = "{102, 802}";
 }
 );
 layerId = UUID0;
@@ -5521,12 +6565,12 @@ name = Anchor18;
 position = "{-107, -295}";
 },
 {
-name = bottom;
-position = "{-109, -266}";
-},
-{
 name = _bottom2;
 position = "{-107, 0}";
+},
+{
+name = bottom;
+position = "{-109, -266}";
 }
 );
 layerId = UUID0;
@@ -5803,12 +6847,12 @@ name = bottom2;
 position = "{396, 0}";
 },
 {
-name = topright;
-position = "{726, 917}";
-},
-{
 name = top;
 position = "{997, 729}";
+},
+{
+name = topright;
+position = "{726, 917}";
 }
 );
 layerId = UUID0;
@@ -5909,20 +6953,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{396, 0}";
-},
-{
-name = topright;
-position = "{393, 697}";
-},
-{
 name = bottom;
 position = "{395, 0}";
 },
 {
+name = bottom2;
+position = "{396, 0}";
+},
+{
 name = top;
 position = "{396, 627}";
+},
+{
+name = topright;
+position = "{393, 697}";
 }
 );
 layerId = UUID0;
@@ -6031,12 +7075,12 @@ name = bottom2;
 position = "{272, -67}";
 },
 {
-name = topright;
-position = "{575, 697}";
-},
-{
 name = top;
 position = "{365, 627}";
+},
+{
+name = topright;
+position = "{575, 697}";
 }
 );
 layerId = UUID0;
@@ -6141,12 +7185,12 @@ name = bottom2;
 position = "{272, -67}";
 },
 {
-name = topright;
-position = "{577, 697}";
-},
-{
 name = top;
 position = "{352, 627}";
+},
+{
+name = topright;
+position = "{577, 697}";
 }
 );
 layerId = UUID0;
@@ -6360,12 +7404,12 @@ name = bottom2;
 position = "{365, -145}";
 },
 {
-name = topright;
-position = "{604, 697}";
-},
-{
 name = top;
 position = "{365, 627}";
+},
+{
+name = topright;
+position = "{604, 697}";
 }
 );
 layerId = UUID0;
@@ -6447,12 +7491,12 @@ name = bottom2;
 position = "{400, -161}";
 },
 {
-name = topright;
-position = "{392, 697}";
-},
-{
 name = top;
 position = "{396, 627}";
+},
+{
+name = topright;
+position = "{392, 697}";
 }
 );
 layerId = UUID0;
@@ -6549,12 +7593,12 @@ name = bottom2;
 position = "{304, -205}";
 },
 {
-name = topright;
-position = "{481, 697}";
-},
-{
 name = top;
 position = "{324, 627}";
+},
+{
+name = topright;
+position = "{481, 697}";
 }
 );
 layerId = UUID0;
@@ -6619,12 +7663,12 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{124, 0}";
-},
-{
 name = bottom;
 position = "{100, 0}";
+},
+{
+name = bottom2;
+position = "{124, 0}";
 }
 );
 components = (
@@ -6651,12 +7695,12 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{120, 0}";
-},
-{
 name = bottom;
 position = "{100, 0}";
+},
+{
+name = bottom2;
+position = "{120, 0}";
 }
 );
 components = (
@@ -6687,12 +7731,12 @@ name = bottom2;
 position = "{337, 40}";
 },
 {
-name = topright;
-position = "{775, 906}";
-},
-{
 name = top;
 position = "{975, 627}";
+},
+{
+name = topright;
+position = "{775, 906}";
 }
 );
 layerId = UUID0;
@@ -6770,12 +7814,12 @@ name = bottom2;
 position = "{374, 0}";
 },
 {
-name = topright;
-position = "{799, 906}";
-},
-{
 name = top;
 position = "{1000, 729}";
+},
+{
+name = topright;
+position = "{799, 906}";
 }
 );
 layerId = UUID0;
@@ -6895,12 +7939,12 @@ name = bottom2;
 position = "{289, -235}";
 },
 {
-name = topright;
-position = "{304, 702}";
-},
-{
 name = top;
 position = "{265, 627}";
+},
+{
+name = topright;
+position = "{304, 702}";
 }
 );
 layerId = UUID0;
@@ -6988,12 +8032,12 @@ name = bottom2;
 position = "{321, -202}";
 },
 {
-name = topright;
-position = "{294, 702}";
-},
-{
 name = top;
 position = "{280, 627}";
+},
+{
+name = topright;
+position = "{294, 702}";
 }
 );
 layerId = UUID0;
@@ -7091,12 +8135,12 @@ name = bottom2;
 position = "{179, 0}";
 },
 {
-name = topright;
-position = "{528, 906}";
-},
-{
 name = top;
 position = "{741, 627}";
+},
+{
+name = topright;
+position = "{528, 906}";
 }
 );
 layerId = UUID0;
@@ -7188,20 +8232,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{179, 0}";
-},
-{
-name = topright;
-position = "{295, 701}";
-},
-{
 name = bottom;
 position = "{324, -85}";
 },
 {
+name = bottom2;
+position = "{179, 0}";
+},
+{
 name = top;
 position = "{281, 627}";
+},
+{
+name = topright;
+position = "{295, 701}";
 }
 );
 layerId = UUID0;
@@ -7920,24 +8964,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{323, -40}";
-},
-{
-name = topright;
-position = "{417, 697}";
+name = Anchor8;
+position = "{379, 0}";
 },
 {
 name = bottom;
 position = "{419, 0}";
 },
 {
+name = bottom2;
+position = "{323, -40}";
+},
+{
 name = top;
 position = "{271, 627}";
 },
 {
-name = Anchor8;
-position = "{379, 0}";
+name = topright;
+position = "{417, 697}";
 }
 );
 layerId = UUID0;
@@ -7995,20 +9039,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{396, -238}";
-},
-{
-name = topright;
-position = "{393, 697}";
-},
-{
 name = bottom;
 position = "{395, -196}";
 },
 {
+name = bottom2;
+position = "{396, -238}";
+},
+{
 name = top;
 position = "{396, 627}";
+},
+{
+name = topright;
+position = "{393, 697}";
 }
 );
 layerId = UUID0;
@@ -8157,20 +9201,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{281, 0}";
-},
-{
-name = topright;
-position = "{415, 697}";
-},
-{
 name = bottom;
 position = "{419, 0}";
 },
 {
+name = bottom2;
+position = "{281, 0}";
+},
+{
 name = top;
 position = "{279, 622}";
+},
+{
+name = topright;
+position = "{415, 697}";
 }
 );
 layerId = UUID0;
@@ -8267,12 +9311,12 @@ name = bottom2;
 position = "{313, -205}";
 },
 {
-name = topright;
-position = "{500, 697}";
-},
-{
 name = top;
 position = "{323, 627}";
+},
+{
+name = topright;
+position = "{500, 697}";
 }
 );
 layerId = UUID0;
@@ -8352,12 +9396,12 @@ name = bottom2;
 position = "{362, -232}";
 },
 {
-name = topright;
-position = "{472, 697}";
-},
-{
 name = top;
 position = "{364, 627}";
+},
+{
+name = topright;
+position = "{472, 697}";
 }
 );
 layerId = UUID0;
@@ -8429,12 +9473,12 @@ name = bottom2;
 position = "{344, -316}";
 },
 {
-name = topright;
-position = "{431, 702}";
-},
-{
 name = top;
 position = "{385, 627}";
+},
+{
+name = topright;
+position = "{431, 702}";
 }
 );
 layerId = UUID0;
@@ -8529,12 +9573,12 @@ name = bottom2;
 position = "{404, -266}";
 },
 {
-name = topright;
-position = "{386, 702}";
-},
-{
 name = top;
 position = "{350, 627}";
+},
+{
+name = topright;
+position = "{386, 702}";
 }
 );
 layerId = UUID0;
@@ -8630,12 +9674,12 @@ name = bottom2;
 position = "{344, -186}";
 },
 {
-name = topright;
-position = "{623, 906}";
-},
-{
 name = top;
 position = "{834, 627}";
+},
+{
+name = topright;
+position = "{623, 906}";
 }
 );
 layerId = UUID0;
@@ -8735,12 +9779,12 @@ name = bottom2;
 position = "{293, 0}";
 },
 {
-name = topright;
-position = "{593, 906}";
-},
-{
 name = top;
 position = "{819, 627}";
+},
+{
+name = topright;
+position = "{593, 906}";
 }
 );
 layerId = UUID0;
@@ -8804,12 +9848,12 @@ name = bottom2;
 position = "{277, 0}";
 },
 {
-name = topright;
-position = "{565, 906}";
-},
-{
 name = top;
 position = "{785, 627}";
+},
+{
+name = topright;
+position = "{565, 906}";
 }
 );
 layerId = UUID0;
@@ -8895,12 +9939,12 @@ name = bottom2;
 position = "{324, 0}";
 },
 {
-name = topright;
-position = "{612, 906}";
-},
-{
 name = top;
 position = "{837, 627}";
+},
+{
+name = topright;
+position = "{612, 906}";
 }
 );
 layerId = UUID0;
@@ -8986,12 +10030,12 @@ name = bottom2;
 position = "{299, 0}";
 },
 {
-name = topright;
-position = "{589, 906}";
-},
-{
 name = top;
 position = "{814, 627}";
+},
+{
+name = topright;
+position = "{589, 906}";
 }
 );
 layerId = UUID0;
@@ -9080,12 +10124,12 @@ name = bottom2;
 position = "{254, 0}";
 },
 {
-name = topright;
-position = "{522, 906}";
-},
-{
 name = top;
 position = "{733, 729}";
+},
+{
+name = topright;
+position = "{522, 906}";
 }
 );
 layerId = UUID0;
@@ -9169,12 +10213,12 @@ name = bottom2;
 position = "{293, 0}";
 },
 {
-name = topright;
-position = "{634, 906}";
-},
-{
 name = top;
 position = "{835, 627}";
+},
+{
+name = topright;
+position = "{634, 906}";
 }
 );
 layerId = UUID0;
@@ -9271,12 +10315,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{602, 906}";
-},
-{
 name = top;
 position = "{837, 627}";
+},
+{
+name = topright;
+position = "{602, 906}";
 }
 );
 layerId = UUID0;
@@ -9379,12 +10423,12 @@ name = bottom2;
 position = "{285, -205}";
 },
 {
-name = topright;
-position = "{461, 697}";
-},
-{
 name = top;
 position = "{314, 627}";
+},
+{
+name = topright;
+position = "{461, 697}";
 }
 );
 layerId = UUID0;
@@ -9450,12 +10494,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{588, 906}";
-},
-{
 name = top;
 position = "{814, 627}";
+},
+{
+name = topright;
+position = "{588, 906}";
 }
 );
 layerId = UUID0;
@@ -9561,12 +10605,12 @@ name = bottom2;
 position = "{246, 0}";
 },
 {
-name = topright;
-position = "{618, 697}";
-},
-{
 name = top;
 position = "{375, 627}";
+},
+{
+name = topright;
+position = "{618, 697}";
 }
 );
 layerId = UUID0;
@@ -9620,12 +10664,12 @@ name = bottom2;
 position = "{167, 97}";
 },
 {
-name = topright;
-position = "{435, 697}";
-},
-{
 name = top;
 position = "{281, 627}";
+},
+{
+name = topright;
+position = "{435, 697}";
 }
 );
 layerId = UUID0;
@@ -9680,12 +10724,12 @@ name = bottom2;
 position = "{300, -205}";
 },
 {
-name = topright;
-position = "{476, 697}";
-},
-{
 name = top;
 position = "{301, 627}";
+},
+{
+name = topright;
+position = "{476, 697}";
 }
 );
 layerId = UUID0;
@@ -9765,12 +10809,12 @@ name = bottom2;
 position = "{170, 100}";
 },
 {
-name = topright;
-position = "{458, 697}";
-},
-{
 name = top;
 position = "{292, 627}";
+},
+{
+name = topright;
+position = "{458, 697}";
 }
 );
 layerId = UUID0;
@@ -9853,12 +10897,12 @@ name = bottom2;
 position = "{179, 127}";
 },
 {
-name = topright;
-position = "{468, 697}";
-},
-{
 name = top;
 position = "{297, 627}";
+},
+{
+name = topright;
+position = "{468, 697}";
 }
 );
 layerId = UUID0;
@@ -9918,12 +10962,12 @@ name = bottom2;
 position = "{239, 198}";
 },
 {
-name = topright;
-position = "{423, 697}";
-},
-{
 name = top;
 position = "{280, 627}";
+},
+{
+name = topright;
+position = "{423, 697}";
 }
 );
 layerId = UUID0;
@@ -9981,12 +11025,12 @@ name = bottom2;
 position = "{209, 162}";
 },
 {
-name = topright;
-position = "{441, 697}";
-},
-{
 name = top;
 position = "{285, 627}";
+},
+{
+name = topright;
+position = "{441, 697}";
 }
 );
 layerId = UUID0;
@@ -10050,12 +11094,12 @@ name = bottom2;
 position = "{333, 0}";
 },
 {
-name = topright;
-position = "{729, 906}";
-},
-{
 name = top;
 position = "{928, 627}";
+},
+{
+name = topright;
+position = "{729, 906}";
 }
 );
 layerId = UUID0;
@@ -10178,12 +11222,12 @@ name = bottom2;
 position = "{230, 104}";
 },
 {
-name = topright;
-position = "{513, 697}";
-},
-{
 name = top;
 position = "{316, 627}";
+},
+{
+name = topright;
+position = "{513, 697}";
 }
 );
 layerId = UUID0;
@@ -10273,12 +11317,12 @@ name = bottom2;
 position = "{194, 134}";
 },
 {
-name = topright;
-position = "{472, 697}";
-},
-{
 name = top;
 position = "{302, 627}";
+},
+{
+name = topright;
+position = "{472, 697}";
 }
 );
 layerId = UUID0;
@@ -10364,12 +11408,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{427, 697}";
-},
-{
 name = top;
 position = "{277, 627}";
+},
+{
+name = topright;
+position = "{427, 697}";
 }
 );
 layerId = UUID0;
@@ -10446,12 +11490,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{427, 697}";
-},
-{
 name = top;
 position = "{282, 627}";
+},
+{
+name = topright;
+position = "{427, 697}";
 }
 );
 layerId = UUID0;
@@ -10551,12 +11595,12 @@ name = bottom2;
 position = "{123, 198}";
 },
 {
-name = topright;
-position = "{320, 697}";
-},
-{
 name = top;
 position = "{223, 627}";
+},
+{
+name = topright;
+position = "{320, 697}";
 }
 );
 layerId = UUID0;
@@ -10600,12 +11644,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{446, 697}";
-},
-{
 name = top;
 position = "{286, 627}";
+},
+{
+name = topright;
+position = "{446, 697}";
 }
 );
 layerId = UUID0;
@@ -10682,12 +11726,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{446, 697}";
-},
-{
 name = top;
 position = "{292, 627}";
+},
+{
+name = topright;
+position = "{446, 697}";
 }
 );
 layerId = UUID0;
@@ -10787,12 +11831,12 @@ name = bottom2;
 position = "{152, 119}";
 },
 {
-name = topright;
-position = "{533, 697}";
-},
-{
 name = top;
 position = "{330, 627}";
+},
+{
+name = topright;
+position = "{533, 697}";
 }
 );
 layerId = UUID0;
@@ -10889,12 +11933,12 @@ name = bottom2;
 position = "{208, 198}";
 },
 {
-name = topright;
-position = "{394, 697}";
-},
-{
 name = top;
 position = "{260, 627}";
+},
+{
+name = topright;
+position = "{394, 697}";
 }
 );
 layerId = UUID0;
@@ -10962,12 +12006,12 @@ name = bottom2;
 position = "{217, 65}";
 },
 {
-name = topright;
-position = "{577, 697}";
-},
-{
 name = top;
 position = "{352, 627}";
+},
+{
+name = topright;
+position = "{577, 697}";
 }
 );
 layerId = UUID0;
@@ -11308,20 +12352,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{710, 56}";
-},
-{
-name = topright;
-position = "{1022, 697}";
-},
-{
 name = bottom;
 position = "{1022, 0}";
 },
 {
+name = bottom2;
+position = "{710, 56}";
+},
+{
 name = top;
 position = "{614, 627}";
+},
+{
+name = topright;
+position = "{1022, 697}";
 }
 );
 layerId = UUID0;
@@ -11445,8 +12489,8 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{963, 697}";
+name = Anchor8;
+position = "{925, 0}";
 },
 {
 name = bottom;
@@ -11457,8 +12501,8 @@ name = top;
 position = "{614, 622}";
 },
 {
-name = Anchor8;
-position = "{925, 0}";
+name = topright;
+position = "{963, 697}";
 }
 );
 layerId = UUID0;
@@ -11578,20 +12622,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
+name = bottom;
 position = "{396, 0}";
 },
 {
-name = topright;
-position = "{393, 697}";
-},
-{
-name = bottom;
+name = bottom2;
 position = "{396, 0}";
 },
 {
 name = top;
 position = "{396, 627}";
+},
+{
+name = topright;
+position = "{393, 697}";
 }
 );
 layerId = UUID0;
@@ -11681,20 +12725,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{323, 0}";
-},
-{
-name = topright;
-position = "{462, 697}";
-},
-{
 name = bottom;
 position = "{466, 0}";
 },
 {
+name = bottom2;
+position = "{323, 0}";
+},
+{
 name = top;
 position = "{304, 627}";
+},
+{
+name = topright;
+position = "{462, 697}";
 }
 );
 layerId = UUID0;
@@ -12740,20 +13784,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{362, -100}";
-},
-{
-name = topright;
-position = "{317, 697}";
-},
-{
 name = bottom;
 position = "{234, -189}";
 },
 {
+name = bottom2;
+position = "{362, -100}";
+},
+{
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{317, 697}";
 }
 );
 layerId = UUID0;
@@ -12863,12 +13907,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{629, 810}";
-},
-{
 name = top;
 position = "{667, 729}";
+},
+{
+name = topright;
+position = "{629, 810}";
 }
 );
 layerId = UUID0;
@@ -12908,12 +13952,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{817, 810}";
-},
-{
 name = top;
 position = "{797, 729}";
+},
+{
+name = topright;
+position = "{817, 810}";
 }
 );
 layerId = UUID0;
@@ -12953,12 +13997,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{910, 810}";
-},
-{
 name = top;
 position = "{910, 729}";
+},
+{
+name = topright;
+position = "{910, 810}";
 }
 );
 layerId = UUID0;
@@ -12998,12 +14042,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{1099, 810}";
-},
-{
 name = top;
 position = "{1099, 729}";
+},
+{
+name = topright;
+position = "{1099, 810}";
 }
 );
 layerId = UUID0;
@@ -13043,12 +14087,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{1295, 810}";
-},
-{
 name = top;
 position = "{1295, 729}";
+},
+{
+name = topright;
+position = "{1295, 810}";
 }
 );
 layerId = UUID0;
@@ -13094,12 +14138,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{1388, 810}";
-},
-{
 name = top;
 position = "{1388, 729}";
+},
+{
+name = topright;
+position = "{1388, 810}";
 }
 );
 layerId = UUID0;
@@ -13145,12 +14189,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{1472, 810}";
-},
-{
 name = top;
 position = "{1472, 729}";
+},
+{
+name = topright;
+position = "{1472, 810}";
 }
 );
 layerId = UUID0;
@@ -13190,12 +14234,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{1574, 810}";
-},
-{
 name = top;
 position = "{1574, 729}";
+},
+{
+name = topright;
+position = "{1574, 810}";
 }
 );
 layerId = UUID0;
@@ -13241,12 +14285,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{1675, 810}";
-},
-{
 name = top;
 position = "{1675, 729}";
+},
+{
+name = topright;
+position = "{1675, 810}";
 }
 );
 layerId = UUID0;
@@ -13295,12 +14339,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{1875, 810}";
-},
-{
 name = top;
 position = "{1875, 729}";
+},
+{
+name = topright;
+position = "{1875, 810}";
 }
 );
 layerId = UUID0;
@@ -13346,12 +14390,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{1975, 810}";
-},
-{
 name = top;
 position = "{1975, 729}";
+},
+{
+name = topright;
+position = "{1975, 810}";
 }
 );
 layerId = UUID0;
@@ -13397,12 +14441,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{2075, 810}";
-},
-{
 name = top;
 position = "{2075, 729}";
+},
+{
+name = topright;
+position = "{2075, 810}";
 }
 );
 layerId = UUID0;
@@ -13448,12 +14492,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{2175, 810}";
-},
-{
 name = top;
 position = "{2175, 729}";
+},
+{
+name = topright;
+position = "{2175, 810}";
 }
 );
 layerId = UUID0;
@@ -13503,20 +14547,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{668, 100}";
-},
-{
-name = topright;
-position = "{1053, 697}";
-},
-{
 name = bottom;
 position = "{1059, 0}";
 },
 {
+name = bottom2;
+position = "{668, 100}";
+},
+{
 name = top;
 position = "{589, 627}";
+},
+{
+name = topright;
+position = "{1053, 697}";
 }
 );
 layerId = UUID0;
@@ -13646,12 +14690,12 @@ name = bottom2;
 position = "{396, -194}";
 },
 {
-name = topright;
-position = "{736, 906}";
-},
-{
 name = top;
 position = "{997, 627}";
+},
+{
+name = topright;
+position = "{736, 906}";
 }
 );
 layerId = UUID0;
@@ -13818,12 +14862,12 @@ name = bottom2;
 position = "{396, 0}";
 },
 {
-name = topright;
-position = "{736, 906}";
-},
-{
 name = top;
 position = "{997, 627}";
+},
+{
+name = topright;
+position = "{736, 906}";
 }
 );
 layerId = UUID0;
@@ -13927,20 +14971,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{402, 0}";
-},
-{
-name = topright;
-position = "{605, 697}";
-},
-{
 name = bottom;
 position = "{608, 0}";
 },
 {
+name = bottom2;
+position = "{402, 0}";
+},
+{
 name = top;
 position = "{354, 627}";
+},
+{
+name = topright;
+position = "{605, 697}";
 }
 );
 layerId = UUID0;
@@ -14007,20 +15051,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{332, 0}";
-},
-{
-name = topright;
-position = "{478, 697}";
-},
-{
 name = bottom;
 position = "{482, 0}";
 },
 {
+name = bottom2;
+position = "{332, 0}";
+},
+{
 name = top;
 position = "{289, 627}";
+},
+{
+name = topright;
+position = "{478, 697}";
 }
 );
 layerId = UUID0;
@@ -14084,20 +15128,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{268, 0}";
-},
-{
-name = topright;
-position = "{435, 697}";
-},
-{
 name = bottom;
 position = "{438, 0}";
 },
 {
+name = bottom2;
+position = "{268, 0}";
+},
+{
 name = top;
 position = "{287, 627}";
+},
+{
+name = topright;
+position = "{435, 697}";
 }
 );
 layerId = UUID0;
@@ -14154,20 +15198,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{302, 0}";
-},
-{
-name = topright;
-position = "{459, 697}";
-},
-{
 name = bottom;
 position = "{457, 0}";
 },
 {
+name = bottom2;
+position = "{302, 0}";
+},
+{
 name = top;
 position = "{292, 627}";
+},
+{
+name = topright;
+position = "{459, 697}";
 }
 );
 layerId = UUID0;
@@ -14240,20 +15284,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{317, 0}";
-},
-{
-name = topright;
-position = "{469, 697}";
-},
-{
 name = bottom;
 position = "{472, 0}";
 },
 {
+name = bottom2;
+position = "{317, 0}";
+},
+{
 name = top;
 position = "{297, 627}";
+},
+{
+name = topright;
+position = "{469, 697}";
 }
 );
 layerId = UUID0;
@@ -14303,20 +15347,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{304, 0}";
-},
-{
-name = topright;
-position = "{442, 697}";
-},
-{
 name = bottom;
 position = "{445, 0}";
 },
 {
+name = bottom2;
+position = "{304, 0}";
+},
+{
 name = top;
 position = "{285, 627}";
+},
+{
+name = topright;
+position = "{442, 697}";
 }
 );
 layerId = UUID0;
@@ -14370,20 +15414,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{329, 0}";
-},
-{
-name = topright;
-position = "{473, 697}";
-},
-{
 name = bottom;
 position = "{476, 0}";
 },
 {
+name = bottom2;
+position = "{329, 0}";
+},
+{
 name = top;
 position = "{306, 627}";
+},
+{
+name = topright;
+position = "{473, 697}";
 }
 );
 layerId = UUID0;
@@ -14467,24 +15511,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{260, 0}";
-},
-{
-name = topright;
-position = "{395, 697}";
+name = Anchor8;
+position = "{357, 0}";
 },
 {
 name = bottom;
 position = "{398, 0}";
 },
 {
+name = bottom2;
+position = "{260, 0}";
+},
+{
 name = top;
 position = "{260, 627}";
 },
 {
-name = Anchor8;
-position = "{357, 0}";
+name = topright;
+position = "{395, 697}";
 }
 );
 layerId = UUID0;
@@ -14542,24 +15586,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{156, 145}";
-},
-{
-name = topright;
-position = "{578, 697}";
+name = Anchor8;
+position = "{540, 0}";
 },
 {
 name = bottom;
 position = "{581, 0}";
 },
 {
+name = bottom2;
+position = "{156, 145}";
+},
+{
 name = top;
 position = "{352, 627}";
 },
 {
-name = Anchor8;
-position = "{540, 0}";
+name = topright;
+position = "{578, 697}";
 }
 );
 layerId = UUID0;
@@ -14643,20 +15687,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{360, 0}";
-},
-{
-name = topright;
-position = "{514, 697}";
-},
-{
 name = bottom;
 position = "{518, 0}";
 },
 {
+name = bottom2;
+position = "{360, 0}";
+},
+{
 name = top;
 position = "{320, 627}";
+},
+{
+name = topright;
+position = "{514, 697}";
 }
 );
 layerId = UUID0;
@@ -14740,20 +15784,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{377, 0}";
-},
-{
-name = topright;
-position = "{449, 697}";
-},
-{
 name = bottom;
 position = "{574, 0}";
 },
 {
+name = bottom2;
+position = "{377, 0}";
+},
+{
 name = top;
 position = "{337, 627}";
+},
+{
+name = topright;
+position = "{449, 697}";
 }
 );
 layerId = UUID0;
@@ -14817,12 +15861,12 @@ name = bottom2;
 position = "{362, -100}";
 },
 {
-name = topright;
-position = "{588, 906}";
-},
-{
 name = top;
 position = "{814, 627}";
+},
+{
+name = topright;
+position = "{588, 906}";
 }
 );
 layerId = UUID0;
@@ -14889,8 +15933,8 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{853, 697}";
+name = Anchor8;
+position = "{815, 0}";
 },
 {
 name = bottom;
@@ -14901,8 +15945,8 @@ name = top;
 position = "{489, 627}";
 },
 {
-name = Anchor8;
-position = "{815, 0}";
+name = topright;
+position = "{853, 697}";
 }
 );
 layerId = UUID0;
@@ -15084,24 +16128,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{665, 100}";
-},
-{
-name = topright;
-position = "{1122, 697}";
+name = Anchor8;
+position = "{1084, 0}";
 },
 {
 name = bottom;
 position = "{1119, 0}";
 },
 {
+name = bottom2;
+position = "{665, 100}";
+},
+{
 name = top;
 position = "{624, 627}";
 },
 {
-name = Anchor8;
-position = "{1084, 0}";
+name = topright;
+position = "{1122, 697}";
 }
 );
 layerId = UUID0;
@@ -15224,20 +16268,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{281, 50}";
-},
-{
-name = topright;
-position = "{436, 697}";
-},
-{
 name = bottom;
 position = "{434, 0}";
 },
 {
+name = bottom2;
+position = "{281, 50}";
+},
+{
 name = top;
 position = "{281, 627}";
+},
+{
+name = topright;
+position = "{436, 697}";
 }
 );
 layerId = UUID0;
@@ -15290,12 +16334,12 @@ name = bottom2;
 position = "{377, 0}";
 },
 {
-name = topright;
-position = "{776, 906}";
-},
-{
 name = top;
 position = "{975, 627}";
+},
+{
+name = topright;
+position = "{776, 906}";
 }
 );
 layerId = UUID0;
@@ -15373,8 +16417,8 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{447, 697}";
+name = Anchor8;
+position = "{409, 0}";
 },
 {
 name = bottom;
@@ -15385,8 +16429,8 @@ name = top;
 position = "{286, 622}";
 },
 {
-name = Anchor8;
-position = "{409, 0}";
+name = topright;
+position = "{447, 697}";
 }
 );
 layerId = UUID0;
@@ -15809,16 +16853,16 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{94, 678}";
-},
-{
 name = _Anchor12;
 position = "{119, 800}";
 },
 {
 name = _topright;
 position = "{119, 800}";
+},
+{
+name = topright;
+position = "{94, 678}";
 }
 );
 layerId = UUID0;
@@ -17918,12 +18962,12 @@ name = bottom2;
 position = "{419, 100}";
 },
 {
-name = topright;
-position = "{841, 697}";
-},
-{
 name = top;
 position = "{524, 627}";
+},
+{
+name = topright;
+position = "{841, 697}";
 }
 );
 layerId = UUID0;
@@ -18000,12 +19044,12 @@ name = bottom2;
 position = "{419, 100}";
 },
 {
-name = topright;
-position = "{1084, 697}";
-},
-{
 name = top;
 position = "{524, 627}";
+},
+{
+name = topright;
+position = "{1084, 697}";
 }
 );
 components = (
@@ -18088,12 +19132,12 @@ name = bottom2;
 position = "{220, 0}";
 },
 {
-name = topright;
-position = "{269, 697}";
-},
-{
 name = top;
 position = "{269, 627}";
+},
+{
+name = topright;
+position = "{269, 697}";
 }
 );
 layerId = UUID0;
@@ -18187,12 +19231,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{337, 869}";
-},
-{
 name = top;
 position = "{439, 516}";
+},
+{
+name = topright;
+position = "{337, 869}";
 }
 );
 layerId = UUID0;
@@ -18304,12 +19348,12 @@ name = bottom2;
 position = "{158, 17}";
 },
 {
-name = topright;
-position = "{513, 697}";
-},
-{
 name = top;
 position = "{320, 627}";
+},
+{
+name = topright;
+position = "{513, 697}";
 }
 );
 layerId = UUID0;
@@ -18398,12 +19442,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{852, 697}";
-},
-{
 name = top;
 position = "{489, 627}";
+},
+{
+name = topright;
+position = "{852, 697}";
 }
 );
 layerId = UUID0;
@@ -18530,12 +19574,12 @@ name = bottom2;
 position = "{92, 20}";
 },
 {
-name = topright;
-position = "{441, 697}";
-},
-{
 name = top;
 position = "{285, 627}";
+},
+{
+name = topright;
+position = "{441, 697}";
 }
 );
 layerId = UUID0;
@@ -18598,12 +19642,12 @@ name = bottom2;
 position = "{294, -205}";
 },
 {
-name = topright;
-position = "{461, 697}";
-},
-{
 name = top;
 position = "{314, 627}";
+},
+{
+name = topright;
+position = "{461, 697}";
 }
 );
 layerId = UUID0;
@@ -18714,12 +19758,12 @@ name = bottom2;
 position = "{149, 17}";
 },
 {
-name = topright;
-position = "{468, 697}";
-},
-{
 name = top;
 position = "{297, 627}";
+},
+{
+name = topright;
+position = "{468, 697}";
 }
 );
 layerId = UUID0;
@@ -18778,12 +19822,12 @@ name = bottom2;
 position = "{313, -205}";
 },
 {
-name = topright;
-position = "{500, 697}";
-},
-{
 name = top;
 position = "{313, 627}";
+},
+{
+name = topright;
+position = "{500, 697}";
 }
 );
 layerId = UUID0;
@@ -18874,12 +19918,12 @@ name = bottom2;
 position = "{304, -205}";
 },
 {
-name = topright;
-position = "{481, 697}";
-},
-{
 name = top;
 position = "{324, 627}";
+},
+{
+name = topright;
+position = "{481, 697}";
 }
 );
 layerId = UUID0;
@@ -18958,12 +20002,12 @@ name = bottom2;
 position = "{362, -232}";
 },
 {
-name = topright;
-position = "{472, 697}";
-},
-{
 name = top;
 position = "{364, 627}";
+},
+{
+name = topright;
+position = "{472, 697}";
 }
 );
 layerId = UUID0;
@@ -19038,12 +20082,12 @@ name = bottom2;
 position = "{365, -145}";
 },
 {
-name = topright;
-position = "{604, 697}";
-},
-{
 name = top;
 position = "{354, 627}";
+},
+{
+name = topright;
+position = "{604, 697}";
 }
 );
 layerId = UUID0;
@@ -19133,12 +20177,12 @@ name = bottom2;
 position = "{269, -21}";
 },
 {
-name = topright;
-position = "{636, 906}";
-},
-{
 name = top;
 position = "{823, 627}";
+},
+{
+name = topright;
+position = "{636, 906}";
 }
 );
 components = (
@@ -19185,20 +20229,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{442, 0}";
-},
-{
-name = topright;
-position = "{797, 697}";
-},
-{
 name = bottom;
 position = "{634, -31}";
 },
 {
+name = bottom2;
+position = "{442, 0}";
+},
+{
 name = top;
 position = "{442, 627}";
+},
+{
+name = topright;
+position = "{797, 697}";
 }
 );
 components = (
@@ -19264,12 +20308,12 @@ name = bottom2;
 position = "{391, -395}";
 },
 {
-name = topright;
-position = "{392, 697}";
-},
-{
 name = top;
 position = "{396, 627}";
+},
+{
+name = topright;
+position = "{392, 697}";
 }
 );
 layerId = UUID0;
@@ -19424,20 +20468,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{786, 56}";
-},
-{
-name = topright;
-position = "{1075, 697}";
-},
-{
 name = bottom;
 position = "{1077, 0}";
 },
 {
+name = bottom2;
+position = "{786, 56}";
+},
+{
 name = top;
 position = "{686, 627}";
+},
+{
+name = topright;
+position = "{1075, 697}";
 }
 );
 components = (
@@ -19523,24 +20567,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{644, 0}";
-},
-{
-name = topright;
-position = "{1022, 697}";
+name = Anchor8;
+position = "{984, 0}";
 },
 {
 name = bottom;
 position = "{1025, 0}";
 },
 {
+name = bottom2;
+position = "{644, 0}";
+},
+{
 name = top;
 position = "{714, 627}";
 },
 {
-name = Anchor8;
-position = "{984, 0}";
+name = topright;
+position = "{1022, 697}";
 }
 );
 layerId = UUID0;
@@ -19671,24 +20715,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{644, 0}";
-},
-{
-name = topright;
-position = "{1022, 697}";
+name = Anchor8;
+position = "{984, 0}";
 },
 {
 name = bottom;
 position = "{1025, 0}";
 },
 {
+name = bottom2;
+position = "{644, 0}";
+},
+{
 name = top;
 position = "{667, 627}";
 },
 {
-name = Anchor8;
-position = "{984, 0}";
+name = topright;
+position = "{1022, 697}";
 }
 );
 components = (
@@ -19781,12 +20825,12 @@ name = bottom2;
 position = "{644, 0}";
 },
 {
-name = topright;
-position = "{1021, 697}";
-},
-{
 name = top;
 position = "{714, 627}";
+},
+{
+name = topright;
+position = "{1021, 697}";
 }
 );
 layerId = UUID0;
@@ -19931,12 +20975,12 @@ name = bottom2;
 position = "{644, 0}";
 },
 {
-name = topright;
-position = "{1075, 697}";
-},
-{
 name = top;
 position = "{667, 627}";
+},
+{
+name = topright;
+position = "{1075, 697}";
 }
 );
 components = (
@@ -20044,12 +21088,12 @@ name = bottom2;
 position = "{644, 56}";
 },
 {
-name = topright;
-position = "{1021, 697}";
-},
-{
 name = top;
 position = "{714, 627}";
+},
+{
+name = topright;
+position = "{1021, 697}";
 }
 );
 layerId = UUID0;
@@ -20191,12 +21235,12 @@ name = bottom2;
 position = "{644, 56}";
 },
 {
-name = topright;
-position = "{1022, 697}";
-},
-{
 name = top;
 position = "{667, 627}";
+},
+{
+name = topright;
+position = "{1022, 697}";
 }
 );
 layerId = UUID0;
@@ -20340,20 +21384,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
+name = bottom;
 position = "{346, -111}";
 },
 {
-name = topright;
-position = "{526, 697}";
-},
-{
-name = bottom;
+name = bottom2;
 position = "{346, -111}";
 },
 {
 name = top;
 position = "{336, 627}";
+},
+{
+name = topright;
+position = "{526, 697}";
 }
 );
 layerId = UUID0;
@@ -20432,12 +21476,12 @@ name = bottom2;
 position = "{346, -111}";
 },
 {
-name = topright;
-position = "{734, 906}";
-},
-{
 name = top;
 position = "{930, 627}";
+},
+{
+name = topright;
+position = "{734, 906}";
 }
 );
 layerId = UUID0;
@@ -20539,12 +21583,12 @@ name = bottom2;
 position = "{400, -161}";
 },
 {
-name = topright;
-position = "{392, 697}";
-},
-{
 name = top;
 position = "{400, 627}";
+},
+{
+name = topright;
+position = "{392, 697}";
 }
 );
 layerId = UUID0;
@@ -20657,24 +21701,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{678, 100}";
-},
-{
-name = topright;
-position = "{1135, 697}";
+name = Anchor8;
+position = "{1097, 0}";
 },
 {
 name = bottom;
 position = "{1138, 0}";
 },
 {
+name = bottom2;
+position = "{678, 100}";
+},
+{
 name = top;
 position = "{637, 627}";
 },
 {
-name = Anchor8;
-position = "{1097, 0}";
+name = topright;
+position = "{1135, 697}";
 }
 );
 components = (
@@ -20763,12 +21807,12 @@ name = bottom2;
 position = "{665, 100}";
 },
 {
-name = topright;
-position = "{1121, 697}";
-},
-{
 name = top;
 position = "{624, 627}";
+},
+{
+name = topright;
+position = "{1121, 697}";
 }
 );
 layerId = UUID0;
@@ -20905,20 +21949,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{684, 100}";
-},
-{
-name = topright;
-position = "{1069, 697}";
-},
-{
 name = bottom;
 position = "{1072, 0}";
 },
 {
+name = bottom2;
+position = "{684, 100}";
+},
+{
 name = top;
 position = "{605, 627}";
+},
+{
+name = topright;
+position = "{1069, 697}";
 }
 );
 components = (
@@ -21006,20 +22050,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{605, 94}";
-},
-{
-name = topright;
-position = "{1053, 697}";
-},
-{
 name = bottom;
 position = "{1058, 0}";
 },
 {
+name = bottom2;
+position = "{605, 94}";
+},
+{
 name = top;
 position = "{589, 627}";
+},
+{
+name = topright;
+position = "{1053, 697}";
 }
 );
 layerId = UUID0;
@@ -21151,12 +22195,12 @@ name = bottom2;
 position = "{605, 94}";
 },
 {
-name = topright;
-position = "{1052, 697}";
-},
-{
 name = top;
 position = "{589, 627}";
+},
+{
+name = topright;
+position = "{1052, 697}";
 }
 );
 components = (
@@ -21192,12 +22236,12 @@ name = bottom2;
 position = "{668, 100}";
 },
 {
-name = topright;
-position = "{1052, 697}";
-},
-{
 name = top;
 position = "{589, 627}";
+},
+{
+name = topright;
+position = "{1052, 697}";
 }
 );
 layerId = UUID0;
@@ -21337,8 +22381,8 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{963, 697}";
+name = Anchor8;
+position = "{925, 0}";
 },
 {
 name = bottom;
@@ -21349,8 +22393,8 @@ name = top;
 position = "{614, 622}";
 },
 {
-name = Anchor8;
-position = "{925, 0}";
+name = topright;
+position = "{963, 697}";
 }
 );
 components = (
@@ -21432,12 +22476,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{962, 697}";
-},
-{
 name = top;
 position = "{614, 622}";
+},
+{
+name = topright;
+position = "{962, 697}";
 }
 );
 layerId = UUID0;
@@ -21575,12 +22619,12 @@ name = bottom2;
 position = "{124, -46}";
 },
 {
-name = topright;
-position = "{472, 697}";
-},
-{
 name = top;
 position = "{302, 627}";
+},
+{
+name = topright;
+position = "{472, 697}";
 }
 );
 layerId = UUID0;
@@ -21678,24 +22722,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{531, -150}";
-},
-{
-name = topright;
-position = "{692, 697}";
+name = Anchor8;
+position = "{654, 0}";
 },
 {
 name = bottom;
 position = "{695, 0}";
 },
 {
+name = bottom2;
+position = "{531, -150}";
+},
+{
 name = top;
 position = "{448, 627}";
 },
 {
-name = Anchor8;
-position = "{654, 0}";
+name = topright;
+position = "{692, 697}";
 }
 );
 layerId = UUID0;
@@ -21760,12 +22804,12 @@ name = bottom2;
 position = "{89, 20}";
 },
 {
-name = topright;
-position = "{414, 697}";
-},
-{
 name = top;
 position = "{280, 627}";
+},
+{
+name = topright;
+position = "{414, 697}";
 }
 );
 layerId = UUID0;
@@ -21831,12 +22875,12 @@ name = bottom2;
 position = "{281, -224}";
 },
 {
-name = topright;
-position = "{416, 697}";
-},
-{
 name = top;
 position = "{271, 627}";
+},
+{
+name = topright;
+position = "{416, 697}";
 }
 );
 layerId = UUID0;
@@ -21942,12 +22986,12 @@ name = bottom2;
 position = "{156, 144}";
 },
 {
-name = topright;
-position = "{577, 697}";
-},
-{
 name = top;
 position = "{352, 627}";
+},
+{
+name = topright;
+position = "{577, 697}";
 }
 );
 layerId = UUID0;
@@ -22049,12 +23093,12 @@ name = bottom2;
 position = "{68, 20}";
 },
 {
-name = topright;
-position = "{394, 697}";
-},
-{
 name = top;
 position = "{260, 627}";
+},
+{
+name = topright;
+position = "{394, 697}";
 }
 );
 layerId = UUID0;
@@ -22130,12 +23174,12 @@ name = bottom2;
 position = "{110, -10}";
 },
 {
-name = topright;
-position = "{458, 697}";
-},
-{
 name = top;
 position = "{292, 627}";
+},
+{
+name = topright;
+position = "{458, 697}";
 }
 );
 layerId = UUID0;
@@ -22226,12 +23270,12 @@ name = bottom2;
 position = "{168, 97}";
 },
 {
-name = topright;
-position = "{435, 697}";
-},
-{
 name = top;
 position = "{281, 627}";
+},
+{
+name = topright;
+position = "{435, 697}";
 }
 );
 layerId = UUID0;
@@ -22294,12 +23338,12 @@ layers = (
 {
 anchors = (
 {
-name = topright;
-position = "{446, 697}";
-},
-{
 name = top;
 position = "{286, 622}";
+},
+{
+name = topright;
+position = "{446, 697}";
 }
 );
 layerId = UUID0;
@@ -22379,12 +23423,12 @@ name = bottom2;
 position = "{134, 0}";
 },
 {
-name = topright;
-position = "{81, 906}";
-},
-{
 name = top;
 position = "{278, 729}";
+},
+{
+name = topright;
+position = "{81, 906}";
 }
 );
 layerId = UUID0;
@@ -22475,24 +23519,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{609, 118}";
-},
-{
-name = topright;
-position = "{853, 697}";
+name = Anchor8;
+position = "{815, 0}";
 },
 {
 name = bottom;
 position = "{856, 0}";
 },
 {
+name = bottom2;
+position = "{609, 118}";
+},
+{
 name = top;
 position = "{489, 627}";
 },
 {
-name = Anchor8;
-position = "{815, 0}";
+name = topright;
+position = "{853, 697}";
 }
 );
 layerId = UUID0;
@@ -22596,12 +23640,12 @@ name = bottom2;
 position = "{589, 89}";
 },
 {
-name = topright;
-position = "{853, 697}";
-},
-{
 name = top;
 position = "{489, 627}";
+},
+{
+name = topright;
+position = "{853, 697}";
 }
 );
 layerId = UUID0;
@@ -22742,20 +23786,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{346, -21}";
-},
-{
-name = topright;
-position = "{525, 697}";
-},
-{
 name = bottom;
 position = "{326, -21}";
 },
 {
+name = bottom2;
+position = "{346, -21}";
+},
+{
 name = top;
 position = "{355, 627}";
+},
+{
+name = topright;
+position = "{525, 697}";
 }
 );
 layerId = UUID0;
@@ -22821,20 +23865,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{532, 0}";
-},
-{
-name = topright;
-position = "{529, 697}";
-},
-{
 name = bottom;
 position = "{531, 0}";
 },
 {
+name = bottom2;
+position = "{532, 0}";
+},
+{
 name = top;
 position = "{532, 627}";
+},
+{
+name = topright;
+position = "{529, 697}";
 }
 );
 background = {
@@ -23086,12 +24130,12 @@ name = bottom2;
 position = "{442, 0}";
 },
 {
-name = topright;
-position = "{1004, 906}";
-},
-{
 name = top;
 position = "{1191, 627}";
+},
+{
+name = topright;
+position = "{1004, 906}";
 }
 );
 components = (
@@ -23161,12 +24205,12 @@ name = bottom2;
 position = "{678, 100}";
 },
 {
-name = topright;
-position = "{1135, 697}";
-},
-{
 name = top;
 position = "{637, 627}";
+},
+{
+name = topright;
+position = "{1135, 697}";
 }
 );
 layerId = UUID0;
@@ -23308,24 +24352,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{580, -10}";
-},
-{
-name = topright;
-position = "{1069, 697}";
+name = Anchor8;
+position = "{1031, 0}";
 },
 {
 name = bottom;
 position = "{1072, 0}";
 },
 {
+name = bottom2;
+position = "{580, -10}";
+},
+{
 name = top;
 position = "{605, 627}";
 },
 {
-name = Anchor8;
-position = "{1031, 0}";
+name = topright;
+position = "{1069, 697}";
 }
 );
 layerId = UUID0;
@@ -23450,12 +24494,12 @@ name = bottom2;
 position = "{580, -10}";
 },
 {
-name = topright;
-position = "{1069, 697}";
-},
-{
 name = top;
 position = "{605, 627}";
+},
+{
+name = topright;
+position = "{1069, 697}";
 }
 );
 layerId = UUID0;
@@ -23586,12 +24630,12 @@ name = bottom2;
 position = "{684, 100}";
 },
 {
-name = topright;
-position = "{1069, 697}";
-},
-{
 name = top;
 position = "{605, 627}";
+},
+{
+name = topright;
+position = "{1069, 697}";
 }
 );
 layerId = UUID0;
@@ -23784,24 +24828,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{719, 69}";
-},
-{
-name = topright;
-position = "{963, 697}";
+name = Anchor8;
+position = "{925, 0}";
 },
 {
 name = bottom;
 position = "{966, 0}";
 },
 {
+name = bottom2;
+position = "{719, 69}";
+},
+{
 name = top;
 position = "{614, 622}";
 },
 {
-name = Anchor8;
-position = "{925, 0}";
+name = topright;
+position = "{963, 697}";
 }
 );
 layerId = UUID0;
@@ -23903,24 +24947,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{689, 83}";
-},
-{
-name = topright;
-position = "{963, 697}";
+name = Anchor8;
+position = "{925, 0}";
 },
 {
 name = bottom;
 position = "{966, 0}";
 },
 {
+name = bottom2;
+position = "{689, 83}";
+},
+{
 name = top;
 position = "{614, 622}";
 },
 {
-name = Anchor8;
-position = "{925, 0}";
+name = topright;
+position = "{963, 697}";
 }
 );
 components = (
@@ -23989,12 +25033,12 @@ name = bottom2;
 position = "{689, 89}";
 },
 {
-name = topright;
-position = "{963, 697}";
-},
-{
 name = top;
 position = "{614, 622}";
+},
+{
+name = topright;
+position = "{963, 697}";
 }
 );
 components = (
@@ -24106,12 +25150,12 @@ name = bottom2;
 position = "{689, 83}";
 },
 {
-name = topright;
-position = "{963, 697}";
-},
-{
 name = top;
 position = "{614, 622}";
+},
+{
+name = topright;
+position = "{963, 697}";
 }
 );
 components = (
@@ -24212,12 +25256,12 @@ name = bottom2;
 position = "{689, 83}";
 },
 {
-name = topright;
-position = "{963, 697}";
-},
-{
 name = top;
 position = "{614, 622}";
+},
+{
+name = topright;
+position = "{963, 697}";
 }
 );
 components = (
@@ -24323,24 +25367,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{346, 0}";
-},
-{
-name = topright;
-position = "{472, 697}";
+name = Anchor8;
+position = "{433, 0}";
 },
 {
 name = bottom;
 position = "{475, 0}";
 },
 {
+name = bottom2;
+position = "{346, 0}";
+},
+{
 name = top;
 position = "{337, 627}";
 },
 {
-name = Anchor8;
-position = "{433, 0}";
+name = topright;
+position = "{472, 697}";
 }
 );
 layerId = UUID0;
@@ -24404,12 +25448,12 @@ name = bottom2;
 position = "{346, 0}";
 },
 {
-name = topright;
-position = "{679, 906}";
-},
-{
 name = top;
 position = "{866, 627}";
+},
+{
+name = topright;
+position = "{679, 906}";
 }
 );
 layerId = UUID0;
@@ -24554,12 +25598,12 @@ name = bottom2;
 position = "{351, -150}";
 },
 {
-name = topright;
-position = "{692, 697}";
-},
-{
 name = top;
 position = "{448, 627}";
+},
+{
+name = topright;
+position = "{692, 697}";
 }
 );
 layerId = UUID0;
@@ -24660,20 +25704,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{239, -5}";
-},
-{
-name = topright;
-position = "{266, 697}";
-},
-{
 name = bottom;
 position = "{373, -138}";
 },
 {
+name = bottom2;
+position = "{239, -5}";
+},
+{
 name = top;
 position = "{307, 627}";
+},
+{
+name = topright;
+position = "{266, 697}";
 }
 );
 layerId = UUID0;
@@ -24771,12 +25815,12 @@ name = bottom2;
 position = "{283, -130}";
 },
 {
-name = topright;
-position = "{602, 906}";
-},
-{
 name = top;
 position = "{816, 627}";
+},
+{
+name = topright;
+position = "{602, 906}";
 }
 );
 layerId = UUID0;
@@ -24917,20 +25961,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{395, 0}";
-},
-{
-name = topright;
-position = "{393, 697}";
-},
-{
 name = bottom;
 position = "{396, 0}";
 },
 {
+name = bottom2;
+position = "{395, 0}";
+},
+{
 name = top;
 position = "{394, 627}";
+},
+{
+name = topright;
+position = "{393, 697}";
 }
 );
 layerId = UUID0;
@@ -25016,12 +26060,12 @@ name = bottom2;
 position = "{395, 0}";
 },
 {
-name = topright;
-position = "{795, 906}";
-},
-{
 name = top;
 position = "{1057, 627}";
+},
+{
+name = topright;
+position = "{795, 906}";
 }
 );
 layerId = UUID0;
@@ -25117,20 +26161,20 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{396, 0}";
+name = Anchor8;
+position = "{355, 0}";
 },
 {
-name = topright;
-position = "{393, 697}";
+name = bottom2;
+position = "{396, 0}";
 },
 {
 name = top;
 position = "{394, 627}";
 },
 {
-name = Anchor8;
-position = "{355, 0}";
+name = topright;
+position = "{393, 697}";
 }
 );
 components = (
@@ -25212,24 +26256,24 @@ layers = (
 {
 anchors = (
 {
-name = bottom2;
-position = "{235, 118}";
-},
-{
-name = topright;
-position = "{428, 697}";
+name = Anchor8;
+position = "{391, 0}";
 },
 {
 name = bottom;
 position = "{433, 0}";
 },
 {
+name = bottom2;
+position = "{235, 118}";
+},
+{
 name = top;
 position = "{313, 627}";
 },
 {
-name = Anchor8;
-position = "{391, 0}";
+name = topright;
+position = "{428, 697}";
 }
 );
 layerId = UUID0;
@@ -25290,12 +26334,12 @@ name = bottom2;
 position = "{190, 133}";
 },
 {
-name = topright;
-position = "{428, 697}";
-},
-{
 name = top;
 position = "{277, 627}";
+},
+{
+name = topright;
+position = "{428, 697}";
 }
 );
 layerId = UUID0;
@@ -25358,12 +26402,12 @@ name = bottom2;
 position = "{132, 143}";
 },
 {
-name = topright;
-position = "{427, 697}";
-},
-{
 name = top;
 position = "{282, 627}";
+},
+{
+name = topright;
+position = "{427, 697}";
 }
 );
 layerId = UUID0;
@@ -25502,12 +26546,12 @@ layers = (
 {
 anchors = (
 {
-name = _bottom;
-position = "{242, 91}";
-},
-{
 name = _Anchor8;
 position = "{201, 91}";
+},
+{
+name = _bottom;
+position = "{242, 91}";
 }
 );
 layerId = UUID0;


### PR DESCRIPTION
The following glyphs have received updated to their shaping:
- KAITHI LETTER A — ktA (U+11083)
- KAITHI LETTER AA — ktAA  (U+11084)
- KAITHI LETTER O — ktO (U+1108B)
- KAITHI LETTER AU — ktAU (U+1108C)

Attempts were made to keep the existing design without including the cursive ball form, but the results looked too similar to the original design in small sizes. A cursive ductus has been used instead, containing a ball terminal/junction similar to /ktSU, /ktSa (U+110AE), and /ktSHa (U+110AC). The picture below shows the old design (on top row) with the new design (on bottom row) highlighted in green.
![newforms](https://github.com/user-attachments/assets/63810b7b-d0e8-450e-ab3b-e1917d9e1182)


The following picture shows the new design balanced against other established characters featuring a similar 'ball like' transition terminal. 
![balls](https://github.com/user-attachments/assets/236c6144-998c-4e82-91cd-deb461d0fe82)

